### PR TITLE
Add development check for Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # ese-tracking
 Repository for the Service-Oriented Software Engineering course
 
+## Documentation
+
+The API is documented using [OpenAPI](https://swagger.io/specification/). The specification file can be found at [`docs/openapi.yaml`](docs/openapi.yaml). When running the server in development mode (`NODE_ENV=development`), the interactive Swagger UI is available at [`/api-docs`](http://localhost:3001/api-docs).

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,479 @@
+openapi: 3.0.0
+info:
+  title: ESE Tracking API
+  version: 1.0.0
+servers:
+  - url: http://localhost:3001/api
+paths:
+  /address:
+    get:
+      summary: List all addresses
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create an address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Address'
+      responses:
+        '201':
+          description: Created
+  /address/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get an address by ID
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not Found
+    put:
+      summary: Update an address
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Address'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete an address
+      responses:
+        '204':
+          description: No Content
+  /collection-schedule:
+    get:
+      summary: List all collection schedules
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create a collection schedule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionSchedule'
+      responses:
+        '201':
+          description: Created
+  /collection-schedule/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get a collection schedule by ID
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not Found
+    put:
+      summary: Update a collection schedule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionSchedule'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete a collection schedule
+      responses:
+        '204':
+          description: No Content
+  /delivery-appointment:
+    get:
+      summary: List all delivery appointments
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create a delivery appointment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeliveryAppointment'
+      responses:
+        '201':
+          description: Created
+  /delivery-appointment/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get a delivery appointment by ID
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not Found
+    put:
+      summary: Update a delivery appointment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeliveryAppointment'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete a delivery appointment
+      responses:
+        '204':
+          description: No Content
+  /delivery-process-status:
+    get:
+      summary: List all delivery process statuses
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create a delivery process status
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeliveryProcessStatus'
+      responses:
+        '201':
+          description: Created
+  /delivery-process-status/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get a delivery process status by ID
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not Found
+    put:
+      summary: Update a delivery process status
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeliveryProcessStatus'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete a delivery process status
+      responses:
+        '204':
+          description: No Content
+  /delivery-process:
+    get:
+      summary: List all delivery processes
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create a delivery process
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeliveryProcess'
+      responses:
+        '201':
+          description: Created
+  /delivery-process/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get a delivery process by ID
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not Found
+    put:
+      summary: Update a delivery process
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeliveryProcess'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete a delivery process
+      responses:
+        '204':
+          description: No Content
+  /fleet:
+    get:
+      summary: List all fleets
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create a fleet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Fleet'
+      responses:
+        '201':
+          description: Created
+  /fleet/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get a fleet by ID
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not Found
+    put:
+      summary: Update a fleet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Fleet'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete a fleet
+      responses:
+        '204':
+          description: No Content
+  /fleet-vehicle:
+    get:
+      summary: List all fleet vehicles
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create a fleet vehicle
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FleetVehicle'
+      responses:
+        '201':
+          description: Created
+  /fleet-vehicle/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get a fleet vehicle by ID
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not Found
+    put:
+      summary: Update a fleet vehicle
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FleetVehicle'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete a fleet vehicle
+      responses:
+        '204':
+          description: No Content
+  /fleet-vehicle-fleet:
+    get:
+      summary: List all fleet vehicle fleet relations
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create a fleet vehicle fleet relation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FleetVehicleFleet'
+      responses:
+        '201':
+          description: Created
+  /fleet-vehicle-fleet/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get a fleet vehicle fleet relation by ID
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not Found
+    put:
+      summary: Update a fleet vehicle fleet relation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FleetVehicleFleet'
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete a fleet vehicle fleet relation
+      responses:
+        '204':
+          description: No Content
+components:
+  schemas:
+    Address:
+      type: object
+      properties:
+        id:
+          type: integer
+        street:
+          type: string
+        number:
+          type: string
+        complement:
+          type: string
+        neighborhood:
+          type: string
+        city:
+          type: string
+        state:
+          type: string
+        postalCode:
+          type: string
+    CollectionSchedule:
+      type: object
+      properties:
+        id:
+          type: integer
+        scheduledTo:
+          type: string
+          format: date-time
+        addressId:
+          type: integer
+    DeliveryAppointment:
+      type: object
+      properties:
+        id:
+          type: integer
+        scheduledTo:
+          type: string
+          format: date-time
+        deliveryProcessId:
+          type: integer
+        addressId:
+          type: integer
+    DeliveryProcessStatus:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    DeliveryProcess:
+      type: object
+      properties:
+        id:
+          type: integer
+        fleetId:
+          type: integer
+        fleetVehicleId:
+          type: integer
+        statusId:
+          type: integer
+        startedAt:
+          type: string
+          format: date-time
+        endedAt:
+          type: string
+          format: date-time
+    Fleet:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    FleetVehicle:
+      type: object
+      properties:
+        id:
+          type: integer
+        model:
+          type: string
+        plate:
+          type: string
+        cpfDriver:
+          type: string
+        renavam:
+          type: string
+    FleetVehicleFleet:
+      type: object
+      properties:
+        id:
+          type: integer
+        fleetVehicleId:
+          type: integer
+        fleetId:
+          type: integer

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "pg": "^8.11.1",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.32.1"
+    ,"swagger-ui-express": "^4.7.2"
+    ,"yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@types/amqplib": "^0.10.7",

--- a/src/infra/http-server/express/express.adapter.ts
+++ b/src/infra/http-server/express/express.adapter.ts
@@ -1,5 +1,8 @@
 import express, { Express } from "express";
 import router from "./routes/router";
+import swaggerUi from "swagger-ui-express";
+import path from "path";
+import YAML from "yamljs";
 
 class ExpressAdapter {
     public app: Express;
@@ -7,6 +10,19 @@ class ExpressAdapter {
     constructor() {
         this.app = express();
         this.app.use(express.json());
+        const isDevelopment = process.env.NODE_ENV === "development";
+        if (isDevelopment) {
+            const specPath = path.resolve(
+                __dirname,
+                "../../../../docs/openapi.yaml"
+            );
+            const openApiDocument = YAML.load(specPath);
+            this.app.use(
+                "/api-docs",
+                swaggerUi.serve,
+                swaggerUi.setup(openApiDocument)
+            );
+        }
         this.app.use("/api", router);
 
         this.app.get("/health", (_, res) => res.send("✅ Tracking service is running"));


### PR DESCRIPTION
## Summary
- serve Swagger UI at `/api-docs` only when `NODE_ENV` is `development`
- clarify in README that Swagger UI is only available in development mode

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f52c4d388333a23da9b230bf0c71